### PR TITLE
Update acf-sidebar_selector-v5.php

### DIFF
--- a/acf-sidebar_selector-v5.php
+++ b/acf-sidebar_selector-v5.php
@@ -94,7 +94,7 @@ class acf_field_sidebar_selector extends acf_field {
 	*/
 
 	function render_field( $field ) {
-
+		global $wp_registered_sidebars;
 
 		?>
 		<div>


### PR DESCRIPTION
De plugin does not render de sidebars. When i add global $wp_registered_sidebars; to ther ender_field() function it works well